### PR TITLE
Group in event

### DIFF
--- a/src/components/view-event-create/view-event-create.component.js
+++ b/src/components/view-event-create/view-event-create.component.js
@@ -5,11 +5,15 @@ import template from './view-event-create.template.html';
 
 import EventsService from './../../services/events/events.service';
 import UserService from './../../services/user/user.service';
+import GroupsService from './../../services/groups/groups.service';
 
 class ViewEventCreateComponent {
     constructor(){
         this.controller = ViewEventCreateComponentController;
         this.template = template;
+        this.bindings = {
+            groups: '<',
+        }
     }
 
     static get name() {
@@ -18,11 +22,22 @@ class ViewEventCreateComponent {
 }
 
 class ViewEventCreateComponentController{
-    constructor($state, EventsService,UserService){
+    constructor($state,$scope, EventsService,UserService,GroupsService){
         this.event = {};
         this.$state = $state;
+        this.$scope = $scope;
         this.EventsService = EventsService;
         this.UserService = UserService;
+        this.GroupsService = GroupsService;
+
+        this.searchText = null;
+    }
+
+    $onInit(){
+        this.groups = this.groups.map( function (group) {
+            group.value = group.title.toLowerCase();
+            return group;
+        });
     }
 
     cancel() {
@@ -40,9 +55,22 @@ class ViewEventCreateComponentController{
 
     };
 
+    getMatches(query) {
+        var results = query ? this.groups.filter(this.createFilterFor(query)) : this.groups;
+        return results;
+    };
+
+    createFilterFor(query) {
+        var lowercaseQuery = angular.lowercase(query);
+
+        return function filterFn(group) {
+            return (group.value.indexOf(lowercaseQuery) === 0);
+        };
+    };
+
 
     static get $inject(){
-        return ['$state', EventsService.name, UserService.name];
+        return ['$state','$scope', EventsService.name, UserService.name, GroupsService.name];
     }
 
 }

--- a/src/components/view-event-create/view-event-create.template.html
+++ b/src/components/view-event-create/view-event-create.template.html
@@ -8,11 +8,26 @@
                 <md-icon><ng-md-icon icon="title" ></ng-md-icon></md-icon>
                 <input ng-model="$ctrl.event.title" type="text">
             </md-input-container>
-            <md-input-container class="md-icon-float md-block">
-                <label>Group</label>
-                <md-icon><ng-md-icon icon="date_range" ></ng-md-icon></md-icon>
-                <input ng-model="$ctrl.event.year" type="text">
-            </md-input-container>
+            <form name="groupForm">
+                <md-autocomplete required
+                    md-input-name="autocompleteField"
+                    md-selected-item="$ctrl.event.group"
+                    md-search-text="$ctrl.searchText"
+                    md-items="group in $ctrl.getMatches($ctrl.searchText)"
+                    md-item-text="group.title"
+                    placeholder="Choose a group">
+                    <md-item-template>
+                        <span md-highlight-text="$ctrl.searchText" md-highlight-flags="^i">{{group.title}}</span>
+                    </md-item-template>
+                    <md-not-found>
+                        No groups matching "{{$ctrl.searchText}}" were found.
+                    </md-not-found>
+                    <div ng-messages="searchForm.autocompleteField.$error" ng-if="groupForm.autocompleteField.$touched">
+                        <div ng-message="required">You <b>must</b> choose a group.</div>
+                        <div ng-message="md-require-match">Please select an existing group.</div>
+                    </div>
+                </md-autocomplete>
+            </form>
             <md-input-container class="md-icon-float md-block">
                 <label>Location</label>
                 <md-icon><ng-md-icon icon="location_on" ></ng-md-icon></md-icon>

--- a/src/components/view-event-create/view-event-create.template.html
+++ b/src/components/view-event-create/view-event-create.template.html
@@ -10,7 +10,6 @@
             </md-input-container>
             <form name="groupForm">
                  <md-autocomplete class="md-icon-float md-block"
-                        required
                         md-input-name="autocompleteField"
                         md-selected-item="$ctrl.event.group"
                         md-search-text="$ctrl.searchText"

--- a/src/components/view-event-create/view-event-create.template.html
+++ b/src/components/view-event-create/view-event-create.template.html
@@ -9,23 +9,21 @@
                 <input ng-model="$ctrl.event.title" type="text">
             </md-input-container>
             <form name="groupForm">
-                <md-autocomplete required
-                    md-input-name="autocompleteField"
-                    md-selected-item="$ctrl.event.group"
-                    md-search-text="$ctrl.searchText"
-                    md-items="group in $ctrl.getMatches($ctrl.searchText)"
-                    md-item-text="group.title"
-                    placeholder="Choose a group">
-                    <md-item-template>
-                        <span md-highlight-text="$ctrl.searchText" md-highlight-flags="^i">{{group.title}}</span>
-                    </md-item-template>
-                    <md-not-found>
-                        No groups matching "{{$ctrl.searchText}}" were found.
-                    </md-not-found>
-                    <div ng-messages="searchForm.autocompleteField.$error" ng-if="groupForm.autocompleteField.$touched">
-                        <div ng-message="required">You <b>must</b> choose a group.</div>
-                        <div ng-message="md-require-match">Please select an existing group.</div>
-                    </div>
+                 <md-autocomplete class="md-icon-float md-block"
+                        required
+                        md-input-name="autocompleteField"
+                        md-selected-item="$ctrl.event.group"
+                        md-search-text="$ctrl.searchText"
+                        md-items="group in $ctrl.getMatches($ctrl.searchText)"
+                        md-item-text="group.title"
+                        md-require-match
+                        md-floating-label="Group">
+                        <md-item-template>
+                            <span md-highlight-text="$ctrl.searchText">{{group.title}}</span>
+                        </md-item-template>
+                        <div ng-messages="searchForm.autocompleteField.$error" ng-if="groupForm.autocompleteField.$touched">
+                            <div ng-message="md-require-match">Please select an existing group.</div>
+                        </div>
                 </md-autocomplete>
             </form>
             <md-input-container class="md-icon-float md-block">

--- a/src/components/view-event-edit/view-event-edit.component.js
+++ b/src/components/view-event-edit/view-event-edit.component.js
@@ -4,6 +4,7 @@
 import template from './view-event-edit.template.html';
 
 import EventsService from './../../services/events/events.service';
+import GroupsService from './../../services/groups/groups.service';
 
 class ViewEventEditComponent {
     constructor(){
@@ -11,6 +12,7 @@ class ViewEventEditComponent {
         this.template = template;
         this.bindings = {
             event: '<',
+            groups: '<',
         }
     }
 
@@ -24,11 +26,21 @@ class ViewEventEditComponentController{
         this.model = {};
         this.$state = $state;
         this.EventsService = EventsService;
+        this.GroupsService = GroupsService;
+
+        this.searchText = null;
     }
 
     $onInit() {
         //Clone the event Data
-        this.model = JSON.parse(JSON.stringify(this.event))
+        this.model = JSON.parse(JSON.stringify(this.event));
+
+        this.groups = this.groups.map( function (group) {
+            group.value = group.title.toLowerCase();
+            return group;
+        });
+
+        this.group = this.groups.find(g => g._id === this.event['group']);
     }
 
     cancel() {
@@ -38,6 +50,7 @@ class ViewEventEditComponentController{
 
     save() {
         let _id = this.event['_id'];
+        this.model['group'] = this.group._id;
 
         this.EventsService.update(this.model).then(data => {
             this.event = JSON.parse(JSON.stringify(data));
@@ -53,6 +66,19 @@ class ViewEventEditComponentController{
         this.EventsService.delete(_id).then(response => {
             this.$state.go('events',{});
         });
+    };
+
+    getMatches(query) {
+        var results = query ? this.groups.filter(this.createFilterFor(query)) : this.groups;
+        return results;
+    };
+
+    createFilterFor(query) {
+        var lowercaseQuery = angular.lowercase(query);
+
+        return function filterFn(group) {
+            return (group.value.indexOf(lowercaseQuery) === 0);
+        };
     };
 
     static get $inject(){

--- a/src/components/view-event-edit/view-event-edit.template.html
+++ b/src/components/view-event-edit/view-event-edit.template.html
@@ -7,11 +7,23 @@
                 <md-icon><ng-md-icon icon="title" ></ng-md-icon></md-icon>
                 <input ng-model="$ctrl.model.title" type="text">
             </md-input-container>
-            <md-input-container class="md-icon-float md-block">
-                <label>Group</label>
-                <md-icon><ng-md-icon icon="group" ></ng-md-icon></md-icon>
-                <input ng-model="$ctrl.model.year" type="text">
-            </md-input-container>
+            <form name="groupForm">
+                 <md-autocomplete class="md-icon-float md-block"
+                        md-input-name="autocompleteField"
+                        md-selected-item="$ctrl.group"
+                        md-search-text="$ctrl.searchText"
+                        md-items="group in $ctrl.getMatches($ctrl.searchText)"
+                        md-item-text="group.title"
+                        md-require-match
+                        md-floating-label="Group">
+                        <md-item-template>
+                            <span md-highlight-text="$ctrl.searchText">{{group.title}}</span>
+                        </md-item-template>
+                        <div ng-messages="searchForm.autocompleteField.$error" ng-if="groupForm.autocompleteField.$touched">
+                            <div ng-message="md-require-match">Please select an existing group.</div>
+                        </div>
+                </md-autocomplete>
+            </form>
             <md-input-container class="md-icon-float md-block">
                 <label>Location</label>
                 <md-icon><ng-md-icon icon="location_on" ></ng-md-icon></md-icon>

--- a/src/components/view-event/view-event.component.js
+++ b/src/components/view-event/view-event.component.js
@@ -63,6 +63,10 @@ class ViewEventComponentController{
         this.$state.go('group',{ groupId:_id});
     };
 
+    groupExists() {
+        return "undefined" !== typeof this.group;
+    }
+
     static get $inject(){
         return ['$state', EventsService.name, UserService.name];
     }

--- a/src/components/view-event/view-event.component.js
+++ b/src/components/view-event/view-event.component.js
@@ -11,6 +11,7 @@ class ViewEventComponent {
         this.template = template;
         this.bindings = {
             event: '<',
+            groups: '<',
         }
 
     }
@@ -27,7 +28,10 @@ class ViewEventComponentController{
         this.$state = $state;
         this.EventsService = EventsService;
         this.UserService = UserService;
+    }
 
+    $onInit () {
+        this.group = this.groups.find(g => g._id === this.event['group']);
     }
 
     edit () {
@@ -54,22 +58,10 @@ class ViewEventComponentController{
         }
     };
 
-
-    getPosterURL(){
-        let posterURL = 'http://placehold.it/32x32';
-        if (this.event.hasOwnProperty('posters')) {
-            if (this.event.posters.hasOwnProperty('thumbnail')) {
-                posterURL = this.event.posters.thumbnail;
-            } else if (this.event.posters.hasOwnProperty('profile')) {
-                posterURL = this.event.posters.profile;
-            } else if (this.event.posters.hasOwnProperty('detailed')) {
-                posterURL = this.event.posters.detailed;
-            } else {
-                posterURL = this.event.posters.original;
-            }
-        }
-        return posterURL;
-    }
+    toGroup() {
+        let _id = this.event['group'];
+        this.$state.go('group',{ groupId:_id});
+    };
 
     static get $inject(){
         return ['$state', EventsService.name, UserService.name];

--- a/src/components/view-event/view-event.template.html
+++ b/src/components/view-event/view-event.template.html
@@ -6,8 +6,11 @@
                 <div layout="column">
                     <span class="md-headline">{{$ctrl.event.title}}</span>
                     <span class="md-subhead">{{$ctrl.event.year}}</span>
-                    <div flex-gt-xs><md-icon><ng-md-icon icon="location_on" ></ng-md-icon></md-icon>
-                        <p>{{$ctrl.event.location}}</p>
+                    <div flex-gt-xs>
+                        <p><md-icon><ng-md-icon icon="location_on" ></ng-md-icon></md-icon> {{$ctrl.event.location}}</p>
+                    </div>
+                    <div>
+                        <md-button md-no-ink class="md-primary" ng-click="$ctrl.toGroup()">{{$ctrl.group.title}}</md-button>
                     </div>
                     <div layout="row">
                         <div layout="column">

--- a/src/components/view-event/view-event.template.html
+++ b/src/components/view-event/view-event.template.html
@@ -9,7 +9,7 @@
                     <div flex-gt-xs>
                         <p><md-icon><ng-md-icon icon="location_on" ></ng-md-icon></md-icon> {{$ctrl.event.location}}</p>
                     </div>
-                    <div>
+                    <div ng-show="$ctrl.groupExists()">
                         <md-button md-no-ink class="md-primary" ng-click="$ctrl.toGroup()">{{$ctrl.group.title}}</md-button>
                     </div>
                     <div layout="row">

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -55,7 +55,10 @@ export default function config ($stateProvider, $urlRouterProvider){
         })
         .state('eventAdd', {
             url: '/events/new',
-            component: EventCreateComponent.name
+            component: EventCreateComponent.name,
+            resolve: {
+                groups : resolveGroups
+            }
         })
         .state('event', {
             url: '/events/:eventId',

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -78,7 +78,8 @@ export default function config ($stateProvider, $urlRouterProvider){
             url: '/events/:eventId/edit',
             component: EventEditComponent.name,
             resolve: {
-                event : resolveEvent
+                event : resolveEvent,
+                groups : resolveGroups
             }
         })
         .state('login', {

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -64,7 +64,8 @@ export default function config ($stateProvider, $urlRouterProvider){
             url: '/events/:eventId',
             component: EventComponent.name,
             resolve: {
-                event : resolveEvent
+                event : resolveEvent,
+                groups : resolveGroups
             }
 
         })


### PR DESCRIPTION
Adding a autocomplete field in 'event create' and 'event edit' that fetches all existing groups and adds the selected one to the event object. In 'event view', if there is a group connected with the event, a link will show up that links to the corresponding group page